### PR TITLE
상품 수정에서 이미지 수정 로직 분리

### DIFF
--- a/src/main/java/com/example/review/domain/items/service/implement/ItemServiceImpl.java
+++ b/src/main/java/com/example/review/domain/items/service/implement/ItemServiceImpl.java
@@ -120,15 +120,14 @@ public class ItemServiceImpl implements ItemService {
             throw new BusinessException(FORBIDDEN_ERROR, "수정할 권한이 없습니다.");
         }
 
-        // 엔티티 수정
+        //엔티티 수정
         item.updateItem(itemRequest.itemName(), itemRequest.price(),
             itemRequest.count(), itemRequest.description(), category, itemRequest.itemState());
 
-        // 상품의 기존 옵션 삭제
+        //상품 옵션 수정
         List<ItemOption> options = itemOptionRepository.findByItem(item); // 아이템 관련해서 아이템 옵션 조회
         itemOptionRepository.deleteAll(options);
 
-        //옵션 DB에 저장
         if (itemRequest.optionValue() != null && !itemRequest.optionValue().isEmpty()) {
             //옵션값 -> 엔티티 변환
             List<ItemOption.Option> optionValues = itemRequest.optionValue().stream()
@@ -140,28 +139,43 @@ public class ItemServiceImpl implements ItemService {
             itemOptionRepository.save(itemOption);
         }
 
-        // S3, 이미지DB 삭제
-        List<ItemImage> imageList = itemImageRepository.findByItem(item);
-        for (ItemImage image : imageList) {
-            String fileName = image.getImageUrl();
-            s3Service.deleteFile(fileName);
-            itemImageRepository.deleteById(image.getItemImageId());
+        //상품 이미지 수정했을 경우
+        if (multipartFiles != null && !multipartFiles.isEmpty()) {
+            List<String> imageUrls = s3Service.upload(multipartFiles);
+            updateImages(item, imageUrls);
         }
-        // S3 이미지 저장
-        List<String> imageUrls = s3Service.upload(multipartFiles);
 
-        // 이미지 정보 저장
-        List<ItemImage> images = imageUrls.stream()
-            .map(img -> ItemImage.builder().imageUrl(img).item(item).build())
-            .toList();
-        itemImageRepository.saveAll(images);
-
-        List<Long> itemImgIds = images.stream().map(ItemImage::getItemImageId).toList();
-
-        return new UpdateItemResponse(itemImgIds, imageUrls);
+        return new UpdateItemResponse(getItemImageIds(item), getItemImageUrls(item));
     }
 
-    // 상품 삭제
+    private void updateImages(Item item, List<String> imageUrls) {
+        //수정 전 기존의 이미지들 삭제
+        List<ItemImage> existingImages = itemImageRepository.findByItem(item);
+        for (ItemImage image : existingImages) {
+            s3Service.deleteFile(image.getImageUrl());
+            itemImageRepository.delete(image);
+        }
+
+        //새로운 이미지 추가
+        List<ItemImage> newImages = imageUrls.stream()
+            .map(url -> ItemImage.builder().imageUrl(url).item(item).build())
+            .toList();
+        itemImageRepository.saveAll(newImages);
+    }
+
+    private List<Long> getItemImageIds(Item item) {
+        return itemImageRepository.findByItem(item).stream()
+            .map(ItemImage::getItemImageId)
+            .toList();
+    }
+
+    private List<String> getItemImageUrls(Item item) {
+        return itemImageRepository.findByItem(item).stream()
+            .map(ItemImage::getImageUrl)
+            .toList();
+    }
+
+    //상품 삭제
     @Override
     @Transactional
     public void delete(Long itemId, Member member) {


### PR DESCRIPTION
**문제 발생**
상품 이미지를 수정하지 않았더라도(예: 상품 수정 시 상품명만 수정) S3 이미지 전체가 삭제되었다가 다시 업로드되는 문제가 생김.

**수정**
상품 이미지를 수정했을 경우에만 s3 이미지를 업로드하고 기존 상품 이미지를 삭제하도록 변경하였음. 상품 이미지를 수정하지 않았을 경우에는 기존 이미지 유지.
